### PR TITLE
fix: ExecTranリクエストにToken/TokenTypeフィールドを追加した

### DIFF
--- a/payment/const.go
+++ b/payment/const.go
@@ -119,3 +119,15 @@ const (
 	// WebhookResultPaymentSlipStatusCancel ... cancel
 	WebhookResultPaymentSlipStatusCancel WebhookResultPaymentSlipStatus = "CANCEL"
 )
+
+// CreditCardTokenType ... credit card token type
+type CreditCardTokenType string
+
+const (
+	CreditCardTokenTypeDefault      CreditCardTokenType = "1"
+	CreditCardTokenTypeGooglePayAPI CreditCardTokenType = "2"
+)
+
+func (tt CreditCardTokenType) String() string {
+	return string(tt)
+}

--- a/payment/tran.go
+++ b/payment/tran.go
@@ -43,16 +43,18 @@ func (cli *Client) EntryTran(
 
 // ExecTranRequest ... exec tran request
 type ExecTranRequest struct {
-	AccessID     string `schema:"AccessID" validate:"required"`
-	AccessPass   string `schema:"AccessPass" validate:"required"`
-	OrderID      string `schema:"OrderID" validate:"required,lte=27"`
-	Method       string `schema:"Method,omitempty"`
-	PayTimes     int    `schema:"PayTimes"`
-	MemberID     string `schema:"MemberID" validate:"required"`
-	SeqMode      string `schema:"SeqMode" validate:"required,len=1"`
-	CardSeq      int    `schema:"CardSeq" validate:"lte=9999"`
-	CardPass     string `schema:"CardPass"`
-	SecurityCode string `schema:"SecurityCode"`
+	AccessID     string              `schema:"AccessID" validate:"required"`
+	AccessPass   string              `schema:"AccessPass" validate:"required"`
+	OrderID      string              `schema:"OrderID" validate:"required,lte=27"`
+	Method       string              `schema:"Method,omitempty"`
+	PayTimes     int                 `schema:"PayTimes"`
+	MemberID     string              `schema:"MemberID" validate:"required"`
+	SeqMode      string              `schema:"SeqMode" validate:"required,len=1"`
+	CardSeq      int                 `schema:"CardSeq" validate:"lte=9999"`
+	CardPass     string              `schema:"CardPass"`
+	SecurityCode string              `schema:"SecurityCode"`
+	Token        string              `schema:"Token,omitempty" validate:"lte=64"`
+	TokenType    CreditCardTokenType `schema:"TokenType,omitempty" validate:"len=1"`
 }
 
 // Validate ... validate


### PR DESCRIPTION
## Proposed Changes

- ExecTranリクエストフィールドにToken,TokenTypeが足りなかったので追加した
- 上記2フィールドはトークン決済の場合だけ使うのでnot-requiredなフィールド
- 文字列長は仕様に沿ってバリデーションを追加した

## Implementation

-
