### PR TITLE
feat: add exec transaction with token

### DIFF
--- a/payment/tran.go
+++ b/payment/tran.go
@@ -41,8 +41,11 @@ func (cli *Client) EntryTran(
 	return res, nil
 }
 
-// ExecTranRequest ... exec tran request
-type ExecTranRequest struct {
+// ExecTranRequest ... exec tran request with member id
+type ExecTranRequest = ExecTranRequestWithMemberID
+
+// ExecTranRequestWithMemberID ... exec tran request with member ID
+type ExecTranRequestWithMemberID struct {
 	AccessID     string `schema:"AccessID" validate:"required"`
 	AccessPass   string `schema:"AccessPass" validate:"required"`
 	OrderID      string `schema:"OrderID" validate:"required,lte=27"`
@@ -57,6 +60,21 @@ type ExecTranRequest struct {
 
 // Validate ... validate
 func (r *ExecTranRequest) Validate() error {
+	return validate.Struct(r)
+}
+
+// ExecTranRequestWithMemberID ... exec tran request with token
+type ExecTranRequestWithToken struct {
+	AccessID   string `schema:"AccessID" validate:"required"`
+	AccessPass string `schema:"AccessPass" validate:"required"`
+	OrderID    string `schema:"OrderID" validate:"required,lte=27"`
+	Method     string `schema:"Method,omitempty"`
+	TokenType  string `schema:"TokenType,omitempty"`
+	Token      string `schema:"Token" validate:"required"`
+}
+
+// Validate ... validate
+func (r *ExecTranRequestWithToken) Validate() error {
 	return validate.Struct(r)
 }
 
@@ -78,9 +96,24 @@ type ExecTranResponse struct {
 	ErrInfo     string `schema:"ErrInfo,omitempty"`
 }
 
-// ExecTran ... exec tran
+// ExecTran ... exec tran with member id
 func (cli *Client) ExecTran(
 	req *ExecTranRequest,
+) (*ExecTranResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	res := &ExecTranResponse{}
+	_, err := cli.do(execTranPath, req, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// ExecTranWithToken exec tran with token
+func (cli *Client) ExecTranWithToken(
+	req *ExecTranRequestWithToken,
 ) (*ExecTranResponse, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err

--- a/payment/tran_test.go
+++ b/payment/tran_test.go
@@ -77,6 +77,39 @@ func TestExecTran(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestExecTranWithToken(t *testing.T) {
+
+	expected := &ExecTranResponse{
+		ACS:    "acs",
+		ACSUrl: "acs_url",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		form := url.Values{}
+		_ = parser.Encoder().Encode(expected, form)
+		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		w.Write([]byte(form.Encode()))
+	}))
+	defer ts.Close()
+	defaultProxy := http.DefaultTransport.(*http.Transport).Proxy
+	http.DefaultTransport.(*http.Transport).Proxy = func(req *http.Request) (*url.URL, error) {
+		return url.Parse(ts.URL)
+	}
+	defer func() { http.DefaultTransport.(*http.Transport).Proxy = defaultProxy }()
+
+	cli, _ := NewClient("siteID", "sitePass", "shopID", "shopPass", false)
+	cli.APIHost = apiHostTest
+	req := &ExecTranRequestWithToken{
+		AccessID:   "accessID",
+		AccessPass: "accessPass",
+		OrderID:    "orderID",
+		TokenType:  "1",
+		Token:      "token",
+	}
+	result, _ := cli.ExecTranWithToken(req)
+	assert.Equal(t, expected, result)
+}
+
 func TestAlterTran(t *testing.T) {
 
 	expected := &AlterTranResponse{


### PR DESCRIPTION
## Proposed Changes

- added a function to use tokens for payment when settling via credit card.
     - Please refer to the official documentation [here](https://gmopg_docs:PF%cwa$GmCC@docs.mul-pay.jp/payment/credit/api#entrytran:~:text=1%EF%BC%9A%E8%BF%94%E5%8D%B4%E3%81%99%E3%82%8B-,%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88,-%E5%90%84%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E3%81%AF)

## Implementation

- add `ExecTranWithToken`
- Since the existing function uses a member ID, we renamed the request structure and set a type alias to limit its impact.
     - `ExecTranRequest` -> `ExecTranRequestWithMemberID`



