### PR TITLE
Add unmarshal error for aozorabank

### DIFF
--- a/aozorabank/auth_client.go
+++ b/aozorabank/auth_client.go
@@ -109,11 +109,7 @@ func (c *AuthClient) doPost(
 	}
 
 	if isError(resp.StatusCode) {
-		errResp := &AuthErrorResponse{}
-		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal error response, bodyBytes=%s,  err=%w", string(bodyBytes), err)
-		}
-		return nil, errResp
+		return nil, c.unmarshalError(bodyBytes)
 	}
 
 	if err := json.Unmarshal(bodyBytes, respBody); err != nil {
@@ -169,11 +165,7 @@ func (c *AuthClient) doGet(
 	}
 
 	if isError(resp.StatusCode) {
-		errResp := &AuthErrorResponse{}
-		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal error response, bodyBytes=%s,  err=%w", string(bodyBytes), err)
-		}
-		return nil, errResp
+		return nil, c.unmarshalError(bodyBytes)
 	}
 
 	if err := json.Unmarshal(bodyBytes, respBody); err != nil {
@@ -181,4 +173,15 @@ func (c *AuthClient) doGet(
 	}
 
 	return resp, nil
+}
+
+func (c *AuthClient) unmarshalError(bodyBytes []byte) error {
+	errResp := &AuthErrorResponse{}
+	if err := json.Unmarshal(bodyBytes, errResp); err != nil {
+		return fmt.Errorf("failed to unmarshal error response, bodyBytes=%s,  err=%w", string(bodyBytes), err)
+	}
+	if errResp.ErrCode == "" {
+		return fmt.Errorf("failed to unmarshal error response, bodyBytes=%s", string(bodyBytes))
+	}
+	return errResp
 }

--- a/aozorabank/auth_client_test.go
+++ b/aozorabank/auth_client_test.go
@@ -1,0 +1,148 @@
+package aozorabank
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func Test_AuthClient_doPost(t *testing.T) {
+	clientID := "client_id"
+	clientSecret := "client_secret"
+	client, _ := NewAuthClient(
+		clientID,
+		clientSecret,
+		ApiHostTypeTest,
+	)
+
+	testCases := map[string]struct {
+		respBody interface{}
+		expected *GetUserInfoResponse
+		respErr  error
+		wantErr  error
+	}{
+		"success": {
+			respBody: &GetUserInfoResponse{
+				Sub: "sub",
+				Iss: "iss",
+				Sup: "sup",
+			},
+			expected: &GetUserInfoResponse{
+				Sub: "sub",
+				Iss: "iss",
+				Sup: "sup",
+			},
+		},
+		"ng": {
+			respErr: &AuthErrorResponse{ErrCode: "code", ErrorDescription: "description", ErrorURI: "uri"},
+			wantErr: &AuthErrorResponse{ErrCode: "code", ErrorDescription: "description", ErrorURI: "uri"},
+		},
+		"ng: failed to unmarshal error response": {
+			respErr: &ErrorResponse{ErrCode: "code", ErrMessage: "message"},
+			wantErr: fmt.Errorf("failed to unmarshal error response, bodyBytes={\"errorCode\":\"code\",\"errorMessage\":\"message\",\"errorDetails\":null,\"transferErrorDetails\":null}\n"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.wantErr != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(tc.respErr)
+					return
+				}
+				json.NewEncoder(w).Encode(tc.respBody)
+			}))
+			defer ts.Close()
+			defaultProxy := http.DefaultTransport.(*http.Transport).Proxy
+			http.DefaultTransport.(*http.Transport).Proxy = func(req *http.Request) (*url.URL, error) {
+				return url.Parse(ts.URL)
+			}
+			defer func() { http.DefaultTransport.(*http.Transport).Proxy = defaultProxy }()
+
+			actual := &GetUserInfoResponse{}
+			_, err := client.doPost(ts.URL, ClientSecretTypeBasic, nil, actual)
+			if tc.wantErr != nil {
+				assert.Equal(t, tc.wantErr, err)
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+
+}
+
+func Test_AuthClient_doGet(t *testing.T) {
+	clientID := "client_id"
+	clientSecret := "client_secret"
+	accessToken := "access_token"
+	client, _ := NewAuthClient(
+		clientID,
+		clientSecret,
+		ApiHostTypeTest,
+	)
+
+	testCases := map[string]struct {
+		respBody interface{}
+		expected *GetUserInfoResponse
+		respErr  error
+		wantErr  error
+	}{
+		"success": {
+			respBody: &GetUserInfoResponse{
+				Sub: "sub",
+				Iss: "iss",
+				Sup: "sup",
+			},
+			expected: &GetUserInfoResponse{
+				Sub: "sub",
+				Iss: "iss",
+				Sup: "sup",
+			},
+		},
+		"ng": {
+			respErr: &AuthErrorResponse{ErrCode: "code", ErrorDescription: "description", ErrorURI: "uri"},
+			wantErr: &AuthErrorResponse{ErrCode: "code", ErrorDescription: "description", ErrorURI: "uri"},
+		},
+		"ng: failed to unmarshal error response": {
+			respErr: &ErrorResponse{ErrCode: "code", ErrMessage: "message"},
+			wantErr: fmt.Errorf("failed to unmarshal error response, bodyBytes={\"errorCode\":\"code\",\"errorMessage\":\"message\",\"errorDetails\":null,\"transferErrorDetails\":null}\n"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.wantErr != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(tc.respErr)
+					return
+				}
+				json.NewEncoder(w).Encode(tc.respBody)
+			}))
+			defer ts.Close()
+			defaultProxy := http.DefaultTransport.(*http.Transport).Proxy
+			http.DefaultTransport.(*http.Transport).Proxy = func(req *http.Request) (*url.URL, error) {
+				return url.Parse(ts.URL)
+			}
+			defer func() { http.DefaultTransport.(*http.Transport).Proxy = defaultProxy }()
+
+			actual := &GetUserInfoResponse{}
+			_, err := client.doGet(ts.URL, accessToken, nil, actual)
+			if tc.wantErr != nil {
+				assert.Equal(t, tc.wantErr, err)
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+
+}

--- a/aozorabank/client.go
+++ b/aozorabank/client.go
@@ -15,9 +15,8 @@ import (
 
 // Client ... gmo pg remittance API client
 type Client struct {
-	cli         *http.Client
-	apiHost     string
-	accessToken string
+	cli     *http.Client
+	apiHost string
 }
 
 // NewClient ... new client
@@ -52,7 +51,7 @@ func (c *Client) doPost(
 	body map[string]interface{},
 	respBody interface{},
 ) (*http.Response, error) {
-	return do(c.cli, c.accessToken, c.apiHost, header, path, http.MethodPost, body, respBody)
+	return do(c.cli, c.apiHost, header, path, http.MethodPost, body, respBody)
 }
 
 func (c *Client) doGet(
@@ -66,12 +65,11 @@ func (c *Client) doGet(
 		values.Add(k, fmt.Sprintf("%s", v))
 	}
 
-	return do(c.cli, c.accessToken, c.apiHost, header, fmt.Sprintf("%s?%s", path, values.Encode()), http.MethodGet, nil, respBody)
+	return do(c.cli, c.apiHost, header, fmt.Sprintf("%s?%s", path, values.Encode()), http.MethodGet, nil, respBody)
 }
 
 func do(
 	cli *http.Client,
-	accessToken string,
 	apiHost string,
 	header http.Header,
 	path string,
@@ -128,6 +126,9 @@ func do(
 		errResp := &ErrorResponse{}
 		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal error response, bodyBytes=%s,  err=%w", string(bodyBytes), err)
+		}
+		if errResp.ErrCode == "" {
+			return nil, fmt.Errorf("failed to unmarshal error response, bodyBytes=%s", string(bodyBytes))
 		}
 		return nil, errResp
 	}

--- a/aozorabank/error_response.go
+++ b/aozorabank/error_response.go
@@ -1,6 +1,8 @@
 package aozorabank
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type ErrorResponse struct {
 	ErrCode              string                `json:"errorCode"`

--- a/aozorabank/transfer_test.go
+++ b/aozorabank/transfer_test.go
@@ -16,7 +16,6 @@ import (
 func TestGetTransferStatus(
 	t *testing.T,
 ) {
-	t.Skip() //FIXME: Skip as it takes a lot of time. I'll fix it later.
 
 	testcases := map[string]struct {
 		request  *GetTransferStatusRequest
@@ -37,7 +36,11 @@ func TestGetTransferStatus(
 				RequestTransferTerm:     RequestTransferTermTransferDesignatedDate,
 			},
 			rawQuery: "accountId=111111111111&applyNo=2018072902345678&dateFrom=2018-07-30&dateTo=2018-08-10&nextItemKey=1234567890&queryKeyClass=1&requestTransferClass=1&requestTransferStatus=%5Bmap%5BrequestTransferStatus%3A2%5D%5D&requestTransferTerm=2",
-			expected: fakeData(GetTransferStatusResponse{}),
+			expected: &GetTransferStatusResponse{
+				AcceptanceKeyClass: "acceptance_key_class",
+				BaseDate:           "2023-08-01",
+				BaseTime:           "00:00:01",
+			},
 		},
 		"ok (required only)": {
 			request: &GetTransferStatusRequest{
@@ -46,7 +49,11 @@ func TestGetTransferStatus(
 				QueryKeyClass: QueryKeyClassTransferApplies,
 			},
 			rawQuery: "accountId=111111111111&queryKeyClass=1",
-			expected: fakeData(GetTransferStatusResponse{}),
+			expected: &GetTransferStatusResponse{
+				AcceptanceKeyClass: "acceptance_key_class",
+				BaseDate:           "2023-08-01",
+				BaseTime:           "00:00:02",
+			},
 		},
 	}
 
@@ -107,7 +114,7 @@ func TestTransferRequest(
 					},
 				},
 			},
-			expected: fakeData(TransferRequestResponse{}),
+			expected: fakeData[TransferRequestResponse](),
 		},
 	}
 
@@ -149,7 +156,7 @@ func TestGetRequestResult(
 				AccountID:   "111111111111",
 				ApplyNo:     "2018072902345678",
 			},
-			expected: fakeData(GetRequestResultResponse{}),
+			expected: fakeData[GetRequestResultResponse](),
 		},
 	}
 
@@ -179,7 +186,7 @@ func TestGetRequestResult(
 	}
 }
 
-func fakeData[T any](t T) *T {
+func fakeData[T any]() *T {
 	ret := new(T)
 	if err := faker.FakeData(ret); err != nil {
 		panic(err)


### PR DESCRIPTION
## Proposed Changes

- 時間がかかるテストについてFIXMEコメントにしていたため修正
  - ネストが深い構造体となっていたため、fakerの生成時に時間がかかっていた。
  - Responseデータについては特に厳密なチェックを行っていないため、時間がかかるものについてはfakerを使用しないようにする
- 一部Responseにてエラーコードが出力されない事象があったためエラーコードが空の場合にはResponseのBodyを出力するように修正

## Implementation

- `aozorabank.TestGetTransferStatus` のテストケースを修正
- aozorabankのClient処理でエラーコードの有無をチェックするように修正
